### PR TITLE
Migrate chatbot to use the Helix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ pip install irc
 To run the chatbot, you will need to provide an OAuth access token with the chat_login scope.  You can reference an authentication sample to accomplish this, or simply use the [Twitch Chat OAuth Password Generator](http://twitchapps.com/tmi/).
 
 ```sh
-$ python chatbot.py <username> <client id> <token> <channel>
+$ python3 chatbot.py <username> <client id> <token> <channel>
 ```
 * Username - The username of the chatbot
 * Client ID - Your registered application's Client ID to allow API calls by the bot

--- a/chatbot.py
+++ b/chatbot.py
@@ -14,12 +14,12 @@ import sys, irc.bot, requests
 class TwitchBot(irc.bot.SingleServerIRCBot):
     def __init__(self, username, client_id, token, channel):
         self.client_id = client_id
-        self.token = token
+        self.token = token.removeprefix("oauth:")
         self.channel = '#' + channel.lower()
 
         # Get the channel id, we will need this for v5 API calls
         url = 'https://api.twitch.tv/kraken/users?login=' + channel
-        headers = {'Client-ID': client_id, 'Accept': 'application/vnd.twitchtv.v5+json', 'Authorization': 'oauth:'+token}
+        headers = {'Client-ID': client_id, 'Accept': 'application/vnd.twitchtv.v5+json', 'Authorization': 'oauth:'+self.token}
         r = requests.get(url, headers=headers).json()
         self.channel_id = r['users'][0]['_id']
 
@@ -27,7 +27,7 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
         server = 'irc.chat.twitch.tv'
         port = 6667
         print('Connecting to ' + server + ' on port ' + str(port) + '...')
-        irc.bot.SingleServerIRCBot.__init__(self, [(server, port, 'oauth:'+token)], username, username)
+        irc.bot.SingleServerIRCBot.__init__(self, [(server, port, 'oauth:'+self.token)], username, username)
         
 
     def on_welcome(self, c, e):

--- a/chatbot.py
+++ b/chatbot.py
@@ -19,7 +19,7 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
 
         # Get the channel id, we will need this for v5 API calls
         url = 'https://api.twitch.tv/kraken/users?login=' + channel
-        headers = {'Client-ID': client_id, 'Accept': 'application/vnd.twitchtv.v5+json', 'Authorization': 'oauth:'+self.token}
+        headers = {'Client-ID': client_id, 'Accept': 'application/vnd.twitchtv.v5+json'}
         r = requests.get(url, headers=headers).json()
         self.channel_id = r['users'][0]['_id']
 

--- a/chatbot.py
+++ b/chatbot.py
@@ -15,7 +15,7 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
     def __init__(self, username, client_id, token, channel):
         self.client_id = client_id
         self.token = token
-        self.channel = '#' + channel
+        self.channel = '#' + channel.lower()
 
         # Get the channel id, we will need this for v5 API calls
         url = 'https://api.twitch.tv/kraken/users?login=' + channel

--- a/chatbot.py
+++ b/chatbot.py
@@ -6,11 +6,10 @@ Licensed under the Apache License, Version 2.0 (the "License"). You may not use 
     http://aws.amazon.com/apache2.0/
 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+Modifications 2021 by RikiRC
 '''
 
-import sys
-import irc.bot
-import requests
+import sys, irc.bot, requests
 
 class TwitchBot(irc.bot.SingleServerIRCBot):
     def __init__(self, username, client_id, token, channel):
@@ -20,32 +19,34 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
 
         # Get the channel id, we will need this for v5 API calls
         url = 'https://api.twitch.tv/kraken/users?login=' + channel
-        headers = {'Client-ID': client_id, 'Accept': 'application/vnd.twitchtv.v5+json'}
+        headers = {'Client-ID': client_id, 'Accept': 'application/vnd.twitchtv.v5+json', 'Authorization': 'oauth:'+token}
         r = requests.get(url, headers=headers).json()
         self.channel_id = r['users'][0]['_id']
 
         # Create IRC bot connection
         server = 'irc.chat.twitch.tv'
         port = 6667
-        print 'Connecting to ' + server + ' on port ' + str(port) + '...'
+        print('Connecting to ' + server + ' on port ' + str(port) + '...')
         irc.bot.SingleServerIRCBot.__init__(self, [(server, port, 'oauth:'+token)], username, username)
         
 
     def on_welcome(self, c, e):
-        print 'Joining ' + self.channel
+        print('Joining ' + self.channel)
 
         # You must request specific capabilities before you can use them
         c.cap('REQ', ':twitch.tv/membership')
         c.cap('REQ', ':twitch.tv/tags')
         c.cap('REQ', ':twitch.tv/commands')
         c.join(self.channel)
+        print('Joined ' + self.channel)
+        c.privmsg(self.channel, "Connected!")
 
     def on_pubmsg(self, c, e):
 
         # If a chat message starts with an exclamation point, try to run it as a command
         if e.arguments[0][:1] == '!':
             cmd = e.arguments[0].split(' ')[0][1:]
-            print 'Received command: ' + cmd
+            print('Received command: ' + cmd)
             self.do_command(e, cmd)
         return
 
@@ -57,14 +58,14 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
             url = 'https://api.twitch.tv/kraken/channels/' + self.channel_id
             headers = {'Client-ID': self.client_id, 'Accept': 'application/vnd.twitchtv.v5+json'}
             r = requests.get(url, headers=headers).json()
-            c.privmsg(self.channel, r['display_name'] + ' is currently playing ' + r['game'])
+            c.privmsg(self.channel, str(r['display_name']) + ' is currently playing ' + str(r['game']))
 
         # Poll the API the get the current status of the stream
         elif cmd == "title":
             url = 'https://api.twitch.tv/kraken/channels/' + self.channel_id
             headers = {'Client-ID': self.client_id, 'Accept': 'application/vnd.twitchtv.v5+json'}
             r = requests.get(url, headers=headers).json()
-            c.privmsg(self.channel, r['display_name'] + ' channel title is currently ' + r['status'])
+            c.privmsg(self.channel, str(r['display_name']) + ' channel title is currently ' + str(r['status']))
 
         # Provide basic information to viewers for specific commands
         elif cmd == "raffle":
@@ -80,7 +81,7 @@ class TwitchBot(irc.bot.SingleServerIRCBot):
 
 def main():
     if len(sys.argv) != 5:
-        print("Usage: twitchbot <username> <client id> <token> <channel>")
+        print('Usage: twitchbot <username> <client id> <token> <channel>')
         sys.exit(1)
 
     username  = sys.argv[1]


### PR DESCRIPTION
With the "Kraken" API no longer being supported, I rewrote the `init` function to work with the Helix API. As a result of this, a client secret is needed in addtion to the client ID and the token.